### PR TITLE
Default outputFileName for markdown to be relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
                     ],
                     "description": "Individual Script Footer"
                 },
+                "combineScripts.markdown.outputFileName": {
+					"type": "string",
+					"default": "${fileWorkspaceFolder}/../combined.md",
+					"description": "Specify the output name of the combined markdown to be 'combined.md'"
+				},
                 "combineScripts.markdown.includeToc": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
It is more user intuitive to see the combined file be in the same folder on the files that they are combining.